### PR TITLE
Update README with credentials passing note

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ To use Telegram Downloader, follow these steps:
    ````
 3. Follow the prompts to log in to Telegram.
 
+#### Note
+
+You can pass credentials directly with `TELEGRAM_CHANNEL=channel TELEGRAM_API_HASH=key php bin/console telegram:download:media`
+
+If you set `variables_order = "EGPCS"` in `/etc/php/php.ini` (`E` is required for ENV).
+
 ## Web Interface (Slim v4)
 The lightweight web UI now runs on [Slim v4](https://www.slimframework.com/).
 Run the built-in server with the Slim front controller:


### PR DESCRIPTION
Added note about passing credentials directly from shell.

I was really confused why I couldn't pass credentials as simple ENV vars.
Took me a while to figure out that you need `variables_order = "EGPCS"` (`E`) for `$_ENV` to work.
On Arch I had it as `GPCS`.
So adding this note.
